### PR TITLE
Generate CI env file from secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,27 @@ jobs:
       #   run: |
       #     rsync -a --delete ./ /srv/AntiFraudKnowledge/
 
+      - name: Generate env file
+        run: |
+          cat <<EOF > config/.env
+          SECRET_KEY=${{ secrets.SECRET_KEY }}
+          DEBUG=${{ secrets.DEBUG }}
+          DB_ENGINE=${{ secrets.DB_ENGINE }}
+          DB_NAME=${{ secrets.DB_NAME }}
+          DB_USER=${{ secrets.DB_USER }}
+          DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+          DB_HOST=${{ secrets.DB_HOST }}
+          DB_PORT=${{ secrets.DB_PORT }}
+          POSTGRES_DB=${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER=${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          NEO4J_URI=${{ secrets.NEO4J_URI }}
+          NEO4J_USERNAME=${{ secrets.NEO4J_USERNAME }}
+          NEO4J_PASSWORD=${{ secrets.NEO4J_PASSWORD }}
+          NEO4J_AUTH=${{ secrets.NEO4J_AUTH }}
+          DASHSCOPE_API_KEY=${{ secrets.DASHSCOPE_API_KEY }}
+          EOF
+
       - name: Deploy locally with Docker Compose
         working-directory: .
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 *.egg-info/
 .env
 .env.production
+config/.env
 env/
 venv/
 pip-log.txt


### PR DESCRIPTION
## Summary
- Create config/.env during deploy job using GitHub Secrets
- Ignore generated config/.env in version control

## Testing
- `python backend/manage.py test` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68b588c4d14c83288b3d4b32ef1690ed